### PR TITLE
Add option : open_by_row

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,6 +62,7 @@ Optional parameters can be used globablly or per cluster and include:
     rank: (true/false)          # Enable sending LC_RANK as an environment variable
     columns: <cols>             # Amount of columns
     rows: <rows>                # Amount of rows
+    open_by_row: (true/false)	# Default : false - Setting true open hosts on by row rather than columns
 
     environment:                # Send the following enviroment variables
         - LC_FOO: foo

--- a/bin/i2cssh
+++ b/bin/i2cssh
@@ -36,7 +36,7 @@ def set_options(config_hash, login_override=nil)
         exit 1
     end
 
-    [:broadcast, :profile, :rank, :iterm2, :login_override, :columns, :rows].each do |p|
+    [:broadcast, :profile, :rank, :iterm2, :login_override, :columns, :rows, :open_by_row].each do |p|
         @i2_options[p] = config_hash[p.to_s].nil? ? @i2_options[p] : config_hash[p.to_s]
     end
 

--- a/lib/i2cssh.rb
+++ b/lib/i2cssh.rb
@@ -53,18 +53,34 @@ class I2Cssh
 
     def split_session
         first = true
-        2.upto @columns do
-          @sys_events.keystroke "d", :using => :command_down
-        end
-        2.upto @rows do
-          1.upto @columns do
-            @sys_events.key_code 123, :using => [:command_down, :option_down] unless first
-            first = false
-          end
-          @columns.times do |x|
-            @sys_events.keystroke "D", :using => :command_down
-            @sys_events.key_code 124, :using => [:command_down, :option_down] unless @columns - 1 == x
-          end
+        if @i2_options[:open_by_row] then
+            2.upto @rows do
+              @sys_events.keystroke "D", :using => :command_down
+            end
+            2.upto @columns do
+              1.upto @rows do
+                @sys_events.key_code 126, :using => [:command_down, :option_down] unless first
+                first = false
+              end
+              @rows.times do |x|
+                @sys_events.keystroke "d", :using => :command_down
+                @sys_events.key_code 125, :using => [:command_down, :option_down] unless @columns - 1 == x
+              end
+            end
+        else
+            2.upto @columns do
+              @sys_events.keystroke "d", :using => :command_down
+            end
+            2.upto @rows do
+              1.upto @columns do
+                @sys_events.key_code 123, :using => [:command_down, :option_down] unless first
+                first = false
+              end
+              @columns.times do |x|
+                @sys_events.keystroke "D", :using => :command_down
+                @sys_events.key_code 124, :using => [:command_down, :option_down] unless @columns - 1 == x
+              end
+            end
         end
     end
 


### PR DESCRIPTION
Hi,

i add an option for opening hosts "by row" rather than "by column".

Indeed if you have in the config file : 
- host1
- host2
- host3
- host4

they are opened like this : 

host1  |  host3
host2  |  host4

which isn't natural for me.

putting open_by_row on true, they are opened like this : 

host1  |  host2
host3  |  host4

The default behavior is not changed if the option is not set. (only changed when setting true for this option)

Best regards.

Benoit
