### PR TITLE
Fix split menu items

### DIFF
--- a/lib/i2cssh.rb
+++ b/lib/i2cssh.rb
@@ -60,8 +60,8 @@ class I2Cssh
         up = @pane_menu.menu_items["Select Pane Above"]
         down = @pane_menu.menu_items["Select Pane Below"]
 
-        split_vert = @shell_menu.menu_items["Split Vertically with Current Profile"]
-        split_hori = @shell_menu.menu_items["Split Horizontally with Current Profile"]
+        split_vert = @shell_menu.menu_items["Split Vertically"]
+        split_hori = @shell_menu.menu_items["Split Horizontally"]
 
         splitmap = {
             :column => {0 => split_vert, 1 => left, 2 => split_hori, 3=> right, :x => @columns, :y => @rows}, 


### PR DESCRIPTION
They changed some item names in recent iTerm, so it's fix.
