### PR TITLE
Ensure each pane is using bash

### DIFF
--- a/lib/i2cssh.rb
+++ b/lib/i2cssh.rb
@@ -101,6 +101,8 @@ class I2Cssh
 
     def start_ssh
         1.upto(@rows*@columns) do |i|
+            @term.sessions[i].write :text => "/bin/bash -l"
+
             server = @servers[i-1]
             if server then
                 ssh_env = ""


### PR DESCRIPTION
@wouterdebie, I'm not sure this is the best way. You could check what shell each pane is using and only change it if it's not bash. But `echo $SHELL` isn't reliable, `ps -p $$` doesn't work in fish, etc...
