### PR TITLE
Changes to support custom commands sent to each window

### DIFF
--- a/bin/i2cssh
+++ b/bin/i2cssh
@@ -180,7 +180,16 @@ end
 @i2_options.merge!(opts_from_cmdline)
 
 if @i2_options[:login] then
-    @servers = @servers.map{|h| "#{@i2_options[:login]}@#{h.gsub(/.+@/,'')}"}
+    @servers = @servers.map { |h|
+      if (server.class == Hash) then
+        server[:login] = @i2_options[:login]
+      else
+        Hash[
+            "name" => h,
+            "login" => @i2_options[:login]
+        ]
+      end
+    }
 end
 
 if @servers.empty?

--- a/lib/i2cssh.rb
+++ b/lib/i2cssh.rb
@@ -81,7 +81,7 @@ class I2Cssh
         end
 
         splitmap = {
-            :column => {0 => split_vert, 1 => left, 2 => split_hori, 3=> right, :x => @columns, :y => @rows}, 
+            :column => {0 => split_vert, 1 => left, 2 => split_hori, 3=> right, :x => @columns, :y => @rows},
             :row => {0 => split_hori, 1=> up, 2 => split_vert, 3=> down, :x => @rows, :y => @columns}
         }
         splitconfig = splitmap[@i2_options[:direction]]
@@ -127,9 +127,19 @@ class I2Cssh
                 if @i2_options[:sleep] then
                     sleep @i2_options[:sleep] * i
                 end
-                @term.sessions[i].write :text => "unset HISTFILE && echo -e \"\\033]50;SetProfile=#{@profile}\\a\" && #{@ssh_prefix} #{send_env} #{server}"
+                if (server.class == Hash) then
+                    server_name = server["name"]
+                    if (server.has_key? "login") then
+                        server_name = "#{server['login']}@#{server_name.gsub(/.+@/,'')}"
+                    end
+                    @term.sessions[i].write :text => "unset HISTFILE && echo -e \"\\033]50;SetProfile=#{@profile}\\a\" && #{@ssh_prefix} #{send_env} #{server_name}"
+                    if (server.has_key? "command") then
+                        @term.sessions[i].write :text => server["command"]
+                    end
+                 else
+                    @term.sessions[i].write :text => "unset HISTFILE && echo -e \"\\033]50;SetProfile=#{@profile}\\a\" && #{@ssh_prefix} #{send_env} #{server}"
+                 end
             else
-                
                 @term.sessions[i].write :text => "unset HISTFILE && echo -e \"\\033]50;SetProfile=#{@profile}\\a\""
                 sleep 0.3
                 @term.sessions[i].foreground_color.set "red"

--- a/test/.i2cssh
+++ b/test/.i2cssh
@@ -1,0 +1,27 @@
+version: 2
+  clusters:
+    testDefault:
+        hosts:
+            - bpu-sek-web02
+    testTwoHosts:
+        hosts:
+            - bpu-sek-web02
+            - bpu-sek-web02
+    testLogin:
+        hosts:
+            - name: bpu-sek-web02
+              login: root
+    testCommands:
+        hosts:
+            - name: bpu-sek-web02
+              command: lt
+            - name: bpu-sek-web02
+              command: cat .bashrc
+    testMixed:
+        hosts:
+            - name: bpu-sek-web02
+              command: lt
+            - bpu-sek-web01
+            - name: bpu-sek-web02
+              login: root
+              command: lt


### PR DESCRIPTION
I love this tool and use it often. Recently I used it to connect to a server and wanted windows open for the access and errors logs of Apache and my app's system and error logs and a postgres window, etc. I got tired to doing that manually. After I did this I noticed the -X argument and that could probably be made to work, but this seems cleaner and a bit easier to use. 

Great project! Thanks for doing this.

Bill