### PR TITLE
Fix -T option not creating ss_environment correctly

### DIFF
--- a/bin/i2cssh
+++ b/bin/i2cssh
@@ -62,6 +62,8 @@ def set_options(config_hash, login_override=nil)
         end
 
         @ssh_environment.last.merge!(config_hash["environment"].inject({}){|m, v| m.merge(v)})
+    else
+        @ssh_environment << {}
     end
 
 end
@@ -237,14 +239,12 @@ elsif ARGV.length > 1
     if opts_from_cmdline[:tabs_nogroup] 
         ARGV.each do |serv|
             @servers << [serv]
-            if @i2_options.size > 1 # We added stuff in with cmdline options
                 @i2_options << @i2_options.first.clone
                 if @ssh_environment.empty?
                     @ssh_environment << {}
                 else
                     @ssh_environment << @ssh_environment.first.clone
                 end
-            end
         end 
     else
         @servers << ARGV
@@ -286,5 +286,6 @@ if @servers.empty?
     puts optparse.help
     exit
 end
+
 
 I2Cssh.new @servers, ssh_options, @i2_options, @ssh_environment

--- a/lib/i2cssh.rb
+++ b/lib/i2cssh.rb
@@ -34,7 +34,7 @@ class I2Cssh
             @i2_options.shift
             @ssh_environment.shift
 
-            if !@servers.empty?  && @i2_options.first[:tabs] then
+            if !@servers.empty?  && i2_options.first[:tabs] then
                 # By default, a new session = a new tab
                 @term.launch_(:session => "Default Session")
             end


### PR DESCRIPTION
Quick fix for the -T option not working. That's what happens when you cut and paste and don't look carefully enough. Sorry about that!