### PR TITLE
Make sure we don't combine if tabs is set

### DIFF
--- a/bin/i2cssh
+++ b/bin/i2cssh
@@ -259,7 +259,6 @@ elsif ARGV.length > 1
     end
 end
 
-
 # Drop default options
 if @i2_options.size > @servers.size
     @i2_options.shift

--- a/lib/i2cssh.rb
+++ b/lib/i2cssh.rb
@@ -141,7 +141,7 @@ class I2Cssh
             @term.sessions[@session_index + i].write :text => "/usr/bin/env bash -l"
             
             # Without the tab flag, combine all servers and clusters into one window
-            if !@servers.empty? && (i - old_size) > @servers.first.size
+            if !@servers.empty? && (i - old_size) > @servers.first.size && !@i2_options.first[:tabs]
                 old_size = @servers.first.size
                 @servers.shift
                 @i2_options.shift


### PR DESCRIPTION
Was playing around some more and realized that if the geometry is not perfect for a previous group, it will add the next groups servers until it is full.

Added an additional check for the combination procedure so it will always split tabs if that is set.

I think this is the last fix from what I could tell. Thanks for merging so quickly!