### PR TITLE
Add in support for gateway SSH connections

### DIFF
--- a/bin/i2cssh
+++ b/bin/i2cssh
@@ -220,7 +220,11 @@ optparse = OptionParser.new do |opts|
 
          ssh_options << "-" + x.split("=").join(" ")
     end
-
+    opts.on '-g', '--gateway HOST', String,
+        'Multihop SSH connection gateway string (e.g. username@gateway) - usually used with -A' do |g|
+            # ssh_gateway = g
+            opts_from_cmdline[:gateway] = g
+    end
 end
 optparse.parse!
 
@@ -276,7 +280,11 @@ end
 @i2_options.each_with_index do |opt, i| 
     if opt[:login] 
         @servers[i] = @servers[i].map{|h| "#{opt[:login]}@#{h.gsub(/.+@/,'')}"}
-    end    
+    end
+    if opt[:gateway]
+        puts opt[:gateway]
+        @servers[i] = @servers[i].map{|h| "#{opt[:gateway]} -t ssh #{h}"}
+    end
 end
 
 


### PR DESCRIPTION
This is sometimes known as multi-hop ssh connections and is achieved using the pseudo tty ssh feature.  The end result is a single command that creates an SSH connection through one or more hosts into the destination host.  This is especially beneficial for connecting through multiple network layers (VLAN's or VPC's) 

Usage:
  -g BASTIONHOST
  -g USERNAME@BASTIONHOST
  -g "USERNAME@BASTIONHOST -i PATH/TO/KEY/FOR/BASTION/CONNECTION"