### PR TITLE
Replace rb-appscript with rb-scpt (fix #46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ pkg
 
 # For rubinius:
 #*.rbc
+
+# IDE metadata
+**/.settings/
+**/.idea/
+**/*.iml

--- a/README.markdown
+++ b/README.markdown
@@ -184,11 +184,6 @@ will result in
 
     ssh -p 2222 -L 8080:localhost:8080
 
-## Known issues
-
-- i2cssh uses rb-appscript and that only seems to work on ruby 1.8.7 and breaks on 1.9.x
-- appscript is no longer supported (http://appscript.sourceforge.net/status.html). This means that i2cssh might have to move to something else in the future. I haven't really looked at anything, but let me know if you find a good alternative!
-
 ## TODO
 
 - Functional parity with csshX (as far as possible)

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ Jeweler::Tasks.new do |gem|
   gem.email = "wouter@evenflow.se"
   gem.authors = ["Wouter de Bie"]
   # dependencies defined in Gemfile
-  gem.add_dependency 'rb-appscript', "~> 0.6.1"
+  gem.add_dependency 'rb-scpt', "~> 1.0.1"
 end
 Jeweler::RubygemsDotOrgTasks.new
 

--- a/i2cssh.gemspec
+++ b/i2cssh.gemspec
@@ -46,20 +46,20 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<jeweler>, ["~> 2.0.0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<builder>, [">= 0"])
-      s.add_runtime_dependency(%q<rb-appscript>, ["~> 0.6.1"])
+      s.add_runtime_dependency(%q<rb-scpt>, ["~> 1.0.1"])
     else
       s.add_dependency(%q<bundler>, [">= 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 2.0.0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<builder>, [">= 0"])
-      s.add_dependency(%q<rb-appscript>, ["~> 0.6.1"])
+      s.add_dependency(%q<rb-scpt>, ["~> 1.0.1"])
     end
   else
     s.add_dependency(%q<bundler>, [">= 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 2.0.0"])
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<builder>, [">= 0"])
-    s.add_dependency(%q<rb-appscript>, ["~> 0.6.1"])
+    s.add_dependency(%q<rb-scpt>, ["~> 1.0.1"])
   end
 end
 

--- a/lib/i2cssh.rb
+++ b/lib/i2cssh.rb
@@ -1,4 +1,4 @@
-require 'appscript'
+require 'rb-scpt'
 class I2Cssh
     def initialize servers, ssh_options, i2_options, ssh_environment
         @ssh_prefix         = "ssh " + ssh_options.join(' ')


### PR DESCRIPTION
As mentioned in #46, I replaced the `rb-appscript` dependency with `rb-scpt`.  Then I tested as follows:

```bash
# ruby 2.1.0
$ rvm use ruby-2.1.0
$ gem build i2cssh.gemspec
$ gem install i2cssh-1.15.0.gem
$ i2cssh stageyarn     # 2-member cluster in .i2csshrc
$ i2cssh prodkafka     # 3-member cluster in .i2csshrc

# ruby 2.3.0
$ rvm use ruby-2.3.0
$ gem build i2cssh.gemspec
$ gem install i2cssh-1.15.0.gem
$ i2cssh stageyarn     # 2-member cluster in .i2csshrc
$ i2cssh prodkafka     # 3-member cluster in .i2csshrc
```

Everything seems to work!  Please double-check what I did, as I'm not very strong in ruby.