### PR TITLE
Run commands with the user's shell

### DIFF
--- a/i2cssh.gemspec
+++ b/i2cssh.gemspec
@@ -15,14 +15,14 @@ Gem::Specification.new do |s|
   s.executables = ["i2cssh"]
   s.extra_rdoc_files = [
     "LICENSE.txt",
-    "README.markdown"
+    "README.md"
   ]
   s.files = [
     ".document",
     "Gemfile",
     "Gemfile.lock",
     "LICENSE.txt",
-    "README.markdown",
+    "README.md",
     "Rakefile",
     "VERSION",
     "bin/i2cssh",

--- a/lib/i2cssh.rb
+++ b/lib/i2cssh.rb
@@ -16,8 +16,9 @@ class I2Cssh
         @shell_menu = @sys_events.processes["iTerm2"].menu_bars[1].menu_bar_items["Shell"].menus["Shell"]
 
         @profile = i2_options.first[:profile] || "Default"
+        @shell = ENV["SHELL"] || "/usr/bin/env bash"
 
-        @iterm.create_window_with_profile(@profile, :command => "/usr/bin/env bash -l")
+        @iterm.create_window_with_profile(@profile, :command => "#{@shell} -l")
         @window = @iterm.current_window
 
         while !@servers.empty? do
@@ -121,7 +122,7 @@ class I2Cssh
         1.upto(@rows*@columns) do |i|
             tab = @window.current_tab
             session = tab.sessions[i]
-            session.write :text => "/usr/bin/env bash -l"
+            session.write :text => "#{@shell} -l"
 
             # Without the tab flag, combine all servers and clusters into one window
             if !@servers.empty? && (i - old_size) > @servers.first.size && !@i2_options.first[:tabs]


### PR DESCRIPTION
This updates the logic to use `ENV["SHELL"]`, if set, and falling back to `/usr/bin/env bash` otherwise when opening a new window and new tabs. Based on [this table](http://hyperpolyglot.org/unix-shells#toc83), many shells support the `-l` option, so this shouldn't have any adverse effects.

The changes to the gemspec were required to get the gem to build properly.