### PR TITLE
use servername as default tab name

### DIFF
--- a/lib/i2cssh.rb
+++ b/lib/i2cssh.rb
@@ -154,7 +154,7 @@ class I2Cssh
                     sleep @i2_options.first[:sleep] * i
                 end
 
-                session.write :text => "unset HISTFILE && echo -e \"\\033]50;SetProfile=#{@profile}\\a\" && #{@ssh_prefix} #{send_env} #{server}"
+                session.write :text => "unset HISTFILE && echo -e \"\\033]1;#{server}\\007\\033]50;SetProfile=#{@profile}\\a\" && #{@ssh_prefix} #{send_env} #{server}"
             else
 
                 session.write :text => "unset HISTFILE && echo -e \"\\033]50;SetProfile=#{@profile}\\a\""


### PR DESCRIPTION
When opening multiple iterm2 windows they all have same name bar 'Default' (if shell does not send change title request, like cisco devices). It's hard to differentiate between them only by looking at prompt. This PR sets default value for tab name to be servername. Later on this could be overridden from login shell (like linux default user@host etc)