### PR TITLE
Add shell option

### DIFF
--- a/bin/i2cssh
+++ b/bin/i2cssh
@@ -46,7 +46,7 @@ def set_options(config_hash, login_override=nil)
         @i2_options << @i2_options.first.clone
     end
 
-    [:broadcast, :profile, :rank, :iterm2, :login, :columns, :rows, :sleep, :direction, :itermname].each do |p|
+    [:broadcast, :profile, :rank, :iterm2, :login, :columns, :rows, :sleep, :shell, :direction, :itermname].each do |p|
         @i2_options.last[p] = config_hash[p.to_s].nil? ? @i2_options.last[p] : config_hash[p.to_s]
     end
 
@@ -205,6 +205,10 @@ optparse = OptionParser.new do |opts|
     opts.on '-s', '--sleep SLEEP', Float,
         'Number of seconds to sleep between creating SSH sessions' do |s|
         opts_from_cmdline[:sleep] = s
+    end
+    opts.on '-S', '--shell SHELL', String,
+        'Shell to use when spawning the SSH sessions' do |s|
+        opts_from_cmdline[:shell] = s
     end
     opts.on "-d", '--direction DIRECTION', String,
         'Direction that new sessions are created (default: column)' do |d|

--- a/lib/i2cssh.rb
+++ b/lib/i2cssh.rb
@@ -16,7 +16,7 @@ class I2Cssh
         @shell_menu = @sys_events.processes["iTerm2"].menu_bars[1].menu_bar_items["Shell"].menus["Shell"]
 
         @profile = i2_options.first[:profile] || "Default"
-        @shell = "/usr/bin/env bash"
+        @shell = "/usr/bin/env #{@i2_options.first[:shell] || 'bash'}"
 
         @iterm.create_window_with_profile(@profile, :command => "#{@shell} -l")
         @window = @iterm.current_window


### PR DESCRIPTION
I originally made a change to use `ENV['SHELL']` in #53 but it was reverted in #54. I would really like to be able to use `zsh` because I have certain SSH settings configured in my zshrc, so this adds a `--shell` option that can be used to override the shell that gets used to spawn the SSH sessions.