### PR TITLE
Avoid creating unnecesary windows (fix #71)

### DIFF
--- a/lib/i2cssh.rb
+++ b/lib/i2cssh.rb
@@ -18,7 +18,7 @@ class I2Cssh
         @profile = i2_options.first[:profile] || "Default"
         @shell = "/usr/bin/env #{@i2_options.first[:shell] || 'bash'}"
 
-        @iterm.create_window_with_profile(@profile, :command => "#{@shell} -l")
+        @iterm.activate()
         @window = @iterm.current_window
 
         while !@servers.empty? do


### PR DESCRIPTION
When the panes are created, the right Profile/Shell is also applied there, so this was not needed