### PR TITLE
bugfix(#79): Only split "-X" argument into 2 pieces

### DIFF
--- a/bin/i2cssh
+++ b/bin/i2cssh
@@ -222,7 +222,7 @@ optparse = OptionParser.new do |opts|
     opts.on '-X', '--extra EXTRA_PARAM', String,
         'Additional ssh parameters (e.g. -Xi=myidentity.pem)' do |x|
 
-         ssh_options << "-" + x.split("=").join(" ")
+         ssh_options << "-" + x.split("=", 2).join(" ")
     end
     opts.on '-g', '--gateway HOST', String,
         'Multihop SSH connection gateway string (e.g. username@gateway) - usually used with -A' do |g|


### PR DESCRIPTION
This fixes the issue described in #79.

Many options to the "ssh -o" flag come in key-value pairs separated by "=" signs. 

Currently, attempting to pass such pairs through the i2cssh "-X" flag will fail with a `command-line line 0: missing argument` error.

E.g. `i2cssh -Xo=StrictHostKeyChecking=no` results in:
```
ssh -o StrictHostKeyChecking no
```
instead of:
```
ssh -o StrictHostKeyChecking=no
```

This because we are splitting up the entire argument based on the "=" sign:
https://github.com/wouterdebie/i2cssh/blob/ac0bf907d78acfa2a0260a27db231f6c7e02d576/bin/i2cssh#L225

By taking advantage of the optional second argument to the Ruby string [#split](https://ruby-doc.org/core-2.4.0/String.html#method-i-split) method, we can ensure we only split on the first occurrence of the "=" sign, which is actually what we wanted all along.

```ruby
➜  irb
irb(main):001:0> "o=StrictHostKeyChecking=no".split("=").join(" ")
=> "o StrictHostKeyChecking no"
irb(main):002:0> "o=StrictHostKeyChecking=no".split("=", 2).join(" ")
=> "o StrictHostKeyChecking=no"
```

@wouterdebie I was going to add a test for this as requested in the README, but given there are no tests to begin I wanted to confirm with you whether it is necessary for this bugfix to be merged. :pray: