### PR TITLE
Use `File.exist?` instead of removed `File.exists?` in Ruby 3.2

### DIFF
--- a/bin/i2cssh
+++ b/bin/i2cssh
@@ -68,7 +68,7 @@ def set_options(config_hash, login_override=nil)
 
 end
 
-if File.exists?(@config_file)
+if File.exist?(@config_file)
     config_hash = YAML.load File.read @config_file
 
     # Read config and set defaults from config


### PR DESCRIPTION
Ruby 3.2 removes deprecated `File.exists?` method.
It will be the following error in Ruby 3.2.

```bash
$ ruby -ve 'File.exists?("foo")'
ruby 3.2.0dev (2022-02-16T04:32:13Z master e7d76fe2b0) [arm64-darwin21]
-e:1:in `<main>': undefined method `exists?' for File:Class (NoMethodError)

File.exists?("foo")
    ^^^^^^^^
Did you mean?  exist?
```