### PR TITLE
Update dependency for i2cssh

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click==8.1.7
 click-option-group==0.5.6
-iterm2==2.9
+iterm2>=2.9
 PyYAML==6.0.2
 shellingham==1.5.4

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         "click-option-group==0.5.6",
         "click==8.1.7",
-        "iterm2==2.9",
+        "iterm2>=2.9",
         "PyYAML==6.0.2",
         "shellingham==1.5.4",
     ],


### PR DESCRIPTION
With python 3.14, the API for asyncio changed; upstream has released 2.11, which fixes the iterm2, but attempting to violates this dependency in i2cssh.
